### PR TITLE
Fix typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Or install it yourself as:
     @client.durations
 
 #### Heartbearts
-    @client.hearbeats
+    @client.heartbeats
 
 #### Current User
     @client.current_user


### PR DESCRIPTION
I found a typo in an example of README.md.

## before

```
#### Heartbearts
@client.hearbeats
```

## after

```
#### Heartbearts
@client.heartbeats
```